### PR TITLE
Specify PHP version compatibility in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0",
+    "php": "^5.6 || ^7.0",
     "yiisoft/yii2": "^2.0",
     "league/oauth2-server": "^6.1",
     "guzzlehttp/guzzle": "^6.3",


### PR DESCRIPTION
Since lcobucci/jwt requires at leas v4.0.0 to be compatible with PHP 8, limit the required PHP version.